### PR TITLE
Improve diff on webhooks to contain url 

### DIFF
--- a/.dothub.repo.yml
+++ b/.dothub.repo.yml
@@ -1,7 +1,43 @@
 collaborators:
   mariocj89:
     permission: admin
+hooks:
+- active: true
+  config:
+    domain: notify.travis-ci.org
+    token: '********'
+    user: Mariocj89
+  events:
+  - create
+  - delete
+  - issue_comment
+  - member
+  - membership
+  - public
+  - pull_request
+  - push
+  - repository
+  name: travis
+- active: true
+  config:
+    content_type: json
+    insecure_ssl: '0'
+    secret: '********'
+    url: https://kolkrabbi.heroku.com/hooks/github
+  events:
+  - '*'
+  name: web
+- active: true
+  config: {}
+  events:
+  - pull_request
+  - pull_request_review_comment
+  - push
+  - status
+  name: landscape
 labels:
+  Hacktoberfest:
+    color: 5319e7
   bug:
     color: ee0701
   enhancement:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,17 @@
 from dothub import utils
 import sealedmock
 
+class StringContains(object):
+    """Ensures the string contains a list of subsrtings"""
+    def __init__(self, *substr):
+        self._substr = substr
+
+    def __eq__(self, other):
+        return all(x in other for x in self._substr)
+
+    def __repr__(self):
+        return "{}({})".format(self.__class__.__name__,
+                               ",".join(["'{}'".format(x) for x in self._substr]))
 
 def test_extract_gh_info_for_ssh():
     owner, repo = utils.extract_gh_info_from_uri("git@github.com:mariocj89/dothub.git")
@@ -66,3 +77,28 @@ def test_confirm_changes_str_unicode_changes_are_ignored(mock_confirm):
 
     utils.confirm_changes(dict(options=u"B"), dict(options="B"))
     assert 0 == mock_confirm.call_count
+
+
+@sealedmock.patch("dothub.utils.LOG.info")
+@sealedmock.patch("dothub.utils.click.confirm")
+def test_output_for_diff_on_web_hooks(mock_confirm, log_info):
+    mock_confirm.return_value = None
+    log_info.return_value = None
+    mock_confirm.sealed = True
+    log_info.sealed = True
+
+    current_hooks = [{
+        "name":"web",
+        "config":{ "url":"http://chooserandom.com"},
+        "active": True
+    }]
+    new_hooks = [{
+        "name":"web",
+        "config":{ "url":"http://chooserandom.com"},
+        "active": False
+    }]
+
+    utils.confirm_changes(dict(hooks=current_hooks), dict(hooks=new_hooks))
+
+    assert 1 == mock_confirm.call_count
+    log_info.assert_any_call(StringContains("C ", "http://chooserandom.com", "True", "False"))


### PR DESCRIPTION
At the moment when a change is performed in a webhook only the number appears which is rather useless. This change includes either the name for services or the url for webhooks